### PR TITLE
fix(demo): Correct sprite path for Vite's import.meta.glob

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -29,7 +29,9 @@ const registeredAnimations: Map<string, AnimateClass> = new Map();
  * Uses Vite's `import.meta.glob` to find all images in the assets directory.
  */
 function getAvailableSprites(): Record<string, { default: string }> {
-    return import.meta.glob('/sprite/*.{png,jpg,jpeg,svg}', { eager: true });
+    // The path must be relative to the current file (main.ts) for import.meta.glob.
+    // Since the vite root is 'demo', we need to go up one level to find the assets folder.
+    return import.meta.glob('../assets/sprite/*.{png,jpg,jpeg,svg}', { eager: true });
 }
 
 /**


### PR DESCRIPTION
The sprite dropdown in the demo was not being populated because `import.meta.glob` was using an incorrect path to find the images.

The Vite configuration sets the `root` to the `demo/` directory. `import.meta.glob` paths starting with `/` are relative to this root, so `/sprite/*` was incorrectly resolving to `/demo/sprite/*`.

This change corrects the path to be a relative filesystem path (`../assets/sprite/*`) from `demo/main.ts` to the actual assets folder, allowing Vite to correctly find the sprite images at build time.