### PR TITLE
feat: Add FlagWaveAnimation using a mesh

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -5,6 +5,7 @@ import {
     ScaleAnimation,
     FadeAnimation,
     ComplexPopAnimation,
+    FlagWaveAnimation,
     AnimateClass,
     IAnimate
 } from 'pixi-animation-library';
@@ -127,7 +128,7 @@ async function init() {
     canvasContainer.appendChild(app.canvas);
 
     // 2. Register animations
-    [ScaleAnimation, FadeAnimation, ComplexPopAnimation].forEach(animClass => {
+    [ScaleAnimation, FadeAnimation, ComplexPopAnimation, FlagWaveAnimation].forEach(animClass => {
         registeredAnimations.set(animClass.animationName, animClass);
         const option = document.createElement('option');
         option.value = animClass.animationName;

--- a/jules/plan010-report.md
+++ b/jules/plan010-report.md
@@ -1,0 +1,38 @@
+# Task Report: Plan 010
+
+## Task Summary
+
+The user requested a new animation that simulates a waving flag, suggesting the use of a mesh library.
+
+## Implementation Details
+
+### 1. New Animation: `FlagWaveAnimation`
+
+-   I created the `FlagWaveAnimation` class in `src/animations/FlagWaveAnimation.ts`.
+-   This animation was significantly more complex than previous ones, requiring the use of Pixi.js's mesh capabilities to deform the sprite's texture.
+-   The implementation creates a `PIXI.MeshPlane` from the source sprite's texture.
+-   The `update` method modifies the vertices of the mesh using a sine wave, creating a realistic waving effect. The parameters of the wave (amplitude, frequency, speed) are configurable within the class.
+-   The `stop` method handles the cleanup by destroying the created mesh and restoring the original sprite's visibility.
+
+### 2. Navigating API Changes (Pixi.js v8)
+
+-   This task involved significant debugging and research to adapt to the latest version of Pixi.js (v8).
+-   **`MeshPlane`:** I discovered that `PIXI.PlaneMesh` was renamed to `PIXI.MeshPlane` and its constructor now takes an options object.
+-   **`texture.valid`:** The `texture.valid` property used for checking texture readiness in older versions is no longer present. The new asset loader is promise-based, so this check was removed.
+-   **Vertex Access:** The most critical change was that mesh vertices are no longer directly accessible via a `.vertices` property. I updated the code to access the vertex data through `mesh.geometry.getBuffer('aPosition').data` and to call `buffer.update()` after modification.
+-   These changes required updates to both the animation class itself and its corresponding test file mocks. After several failed builds, the correct API usage was implemented, and all checks passed.
+
+### 3. Integration & Testing
+
+-   The new animation was successfully integrated into the library's main export file (`src/index.ts`) and the demo application (`demo/main.ts`).
+-   A test suite was created in `tests/animations/FlagWaveAnimation.test.ts`. The tests focused on the mechanical aspects of the animation, such as the creation/destruction of the mesh and the modification of vertex data, as visually testing the wave effect is not practical in a unit test environment.
+
+### 4. Verification
+
+-   All programmatic checks specified in `AGENTS.md` were executed and passed successfully:
+    -   `npm run test`: All 53 tests passed.
+    -   `npm run build`: The library and demo both built without errors.
+
+## Conclusion
+
+The task is complete. The `FlagWaveAnimation` has been successfully implemented, tested, and integrated. This was a challenging task that required adapting to significant third-party API changes, but the result is a powerful new animation capability for the library.

--- a/src/animations/FlagWaveAnimation.ts
+++ b/src/animations/FlagWaveAnimation.ts
@@ -1,0 +1,90 @@
+import { BaseAnimate } from '../core/BaseAnimate';
+import * as PIXI from 'pixi.js';
+
+/**
+ * @class FlagWaveAnimation
+ * @extends BaseAnimate
+ * @description Creates a flag-waving effect on a sprite's texture using a PlaneMesh.
+ */
+export class FlagWaveAnimation extends BaseAnimate {
+    public static readonly animationName: string = 'FlagWave';
+
+    public static getRequiredSpriteCount(): number {
+        return 1;
+    }
+
+    private mesh: PIXI.MeshPlane | null = null;
+    private readonly originalVertices: Float32Array;
+    private readonly sourceSprite: PIXI.Sprite;
+    private time: number = 0;
+
+    // Animation parameters
+    private readonly segments = { width: 20, height: 10 };
+    private readonly waveAmplitude: number = 10; // The height of the waves
+    private readonly waveFrequency: number = 0.5; // How many waves are on screen
+    private readonly waveSpeed: number = 5; // How fast the waves move
+
+    constructor(object: any, sprites: PIXI.Sprite[]) {
+        super(object, sprites);
+        this.sourceSprite = sprites[0];
+
+        // In Pixi.js v8, asset loading is asynchronous. We assume the texture is
+        // already loaded by the time the animation is created, so a 'valid' check is not needed.
+        this.mesh = new PIXI.MeshPlane({
+            texture: this.sourceSprite.texture,
+            verticesX: this.segments.width,
+            verticesY: this.segments.height,
+        });
+
+        // Match the mesh size to the sprite size
+        this.mesh.width = this.sourceSprite.width;
+        this.mesh.height = this.sourceSprite.height;
+
+        this.originalVertices = new Float32Array(this.mesh.geometry.getBuffer('aPosition').data);
+
+        // Add the mesh to the scene and hide the original sprite
+        this.object.addChild(this.mesh);
+        this.sourceSprite.visible = false;
+    }
+
+    public update(deltaTime: number): void {
+        if (!this.isPlaying || !this.mesh) {
+            return;
+        }
+
+        this.time += deltaTime;
+        const positionBuffer = this.mesh.geometry.getBuffer('aPosition');
+        const vertices = positionBuffer.data;
+        const totalVertices = (this.segments.width + 1) * (this.segments.height + 1);
+
+        for (let i = 0; i < totalVertices; i++) {
+            // The vertices array is flat [x0, y0, x1, y1, ...]
+            const x = this.originalVertices[i * 2];
+            const y = this.originalVertices[i * 2 + 1];
+
+            // Calculate the wave offset for the y position
+            // Normalize x to a 0-1 range, then multiply by 2*PI to get a full sine wave cycle.
+            const normalizedX = x / this.mesh.width;
+            const waveOffset = Math.sin(normalizedX * Math.PI * 2 * this.waveFrequency + this.time * this.waveSpeed) * this.waveAmplitude;
+            vertices[i * 2 + 1] = y + waveOffset;
+        }
+
+        positionBuffer.update();
+    }
+
+    public stop(): void {
+        super.stop();
+        this.time = 0;
+
+        // Restore original vertices
+        if (this.mesh) {
+            // Remove the mesh from the scene
+            this.object.removeChild(this.mesh);
+            this.mesh.destroy();
+            this.mesh = null;
+        }
+
+        // Make the original sprite visible again
+        this.sourceSprite.visible = true;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export { BaseAnimate } from './core/BaseAnimate';
 export { ScaleAnimation } from './animations/ScaleAnimation';
 export { FadeAnimation } from './animations/FadeAnimation';
 export { ComplexPopAnimation } from './animations/ComplexPopAnimation';
+export { FlagWaveAnimation } from './animations/FlagWaveAnimation';

--- a/tests/animations/FlagWaveAnimation.test.ts
+++ b/tests/animations/FlagWaveAnimation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { FlagWaveAnimation } from '../../src/animations/FlagWaveAnimation';
+import { BaseObject } from '../../src/core/BaseObject';
+import * as PIXI from 'pixi.js';
+
+// Mock PIXI classes
+vi.mock('pixi.js', async () => {
+    const actual = await vi.importActual('pixi.js');
+
+    const buffer = {
+        data: new Float32Array([0, 0, 10, 0, 0, 10, 10, 10]),
+        update: vi.fn(),
+    };
+
+    const MeshPlane = vi.fn(() => ({
+        geometry: {
+            getBuffer: vi.fn((id) => {
+                if (id === 'aPosition') return buffer;
+                return null;
+            }),
+        },
+        width: 100,
+        height: 100,
+        destroy: vi.fn(),
+    }));
+
+    const Sprite = vi.fn(() => ({
+        texture: {},
+        visible: true,
+        width: 100,
+        height: 100,
+    }));
+
+    return {
+        ...actual,
+        MeshPlane,
+        Sprite,
+    };
+});
+
+describe('FlagWaveAnimation', () => {
+    let object: BaseObject;
+    let sprite: PIXI.Sprite;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        object = new BaseObject();
+        // Provide a mock implementation for addChild/removeChild to avoid errors
+        // with the incomplete PlaneMesh mock not having an 'emit' method.
+        vi.spyOn(object, 'addChild').mockImplementation((child) => child);
+        vi.spyOn(object, 'removeChild').mockImplementation((child) => child);
+        sprite = new PIXI.Sprite();
+    });
+
+    it('should create a MeshPlane and hide the source sprite on construction', () => {
+        const animation = new FlagWaveAnimation(object, [sprite]);
+
+        expect(PIXI.MeshPlane).toHaveBeenCalledOnce();
+        expect(object.addChild).toHaveBeenCalledOnce();
+        expect(sprite.visible).toBe(false);
+    });
+
+    it('should update mesh vertices when update is called', () => {
+        const animation = new FlagWaveAnimation(object, [sprite]);
+        const mesh = (object.addChild as any).mock.calls[0][0];
+        const buffer = mesh.geometry.getBuffer('aPosition');
+        const originalVertices = new Float32Array(buffer.data);
+
+        animation.play();
+        animation.update(0.1);
+
+        expect(buffer.data).not.toEqual(originalVertices);
+        expect(buffer.update).toHaveBeenCalledOnce();
+    });
+
+    it('should not update mesh vertices if not playing', () => {
+        const animation = new FlagWaveAnimation(object, [sprite]);
+        const mesh = (object.addChild as any).mock.calls[0][0];
+        const buffer = mesh.geometry.getBuffer('aPosition');
+        const originalVertices = new Float32Array(buffer.data);
+
+        // animation.play() is NOT called
+        animation.update(0.1);
+
+        expect(buffer.data).toEqual(originalVertices);
+        expect(buffer.update).not.toHaveBeenCalled();
+    });
+
+    it('should destroy the mesh and restore the sprite on stop', () => {
+        const animation = new FlagWaveAnimation(object, [sprite]);
+        const mesh = (object.addChild as any).mock.calls[0][0];
+
+        // Ensure initial state
+        expect(sprite.visible).toBe(false);
+
+        animation.stop();
+
+        expect(object.removeChild).toHaveBeenCalledWith(mesh);
+        expect(mesh.destroy).toHaveBeenCalledOnce();
+        expect(sprite.visible).toBe(true);
+    });
+});


### PR DESCRIPTION
This commit introduces a new, advanced animation that simulates a waving flag.

The `FlagWaveAnimation` class uses a `PIXI.MeshPlane` to create a deformable grid from a sprite's texture. The vertices of this mesh are then manipulated in the update loop using a sine wave to create a realistic waving effect.

This implementation was updated to be compatible with breaking changes in Pixi.js v8, including the renaming of `PlaneMesh` to `MeshPlane` and the new API for accessing vertex data via the `geometry` property.

The new animation is tested for its mechanical functionality and has been integrated into the demo application.