### PR TITLE
feat: Add VortexAnimation for a black hole effect

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -6,6 +6,7 @@ import {
     FadeAnimation,
     ComplexPopAnimation,
     FlagWaveAnimation,
+    VortexAnimation,
     AnimateClass,
     IAnimate
 } from 'pixi-animation-library';
@@ -128,7 +129,7 @@ async function init() {
     canvasContainer.appendChild(app.canvas);
 
     // 2. Register animations
-    [ScaleAnimation, FadeAnimation, ComplexPopAnimation, FlagWaveAnimation].forEach(animClass => {
+    [ScaleAnimation, FadeAnimation, ComplexPopAnimation, FlagWaveAnimation, VortexAnimation].forEach(animClass => {
         registeredAnimations.set(animClass.animationName, animClass);
         const option = document.createElement('option');
         option.value = animClass.animationName;

--- a/jules/plan011-report.md
+++ b/jules/plan011-report.md
@@ -1,0 +1,31 @@
+# Task Report: Plan 011
+
+## Task Summary
+
+The user requested a "black hole" animation where a sprite appears to be rotated and pulled into its center over a 3-second duration.
+
+## Implementation Details
+
+### 1. New Animation: `VortexAnimation`
+
+-   I created the `VortexAnimation` class in `src/animations/VortexAnimation.ts`.
+-   Following the successful pattern from the `FlagWaveAnimation`, this animation uses a `PIXI.MeshPlane` to deform the sprite's texture. A 20x20 grid was used to ensure a smooth visual effect.
+-   The core of the animation is in the `update` method, which uses polar coordinates to achieve the vortex effect. For each vertex in the mesh, its position is converted to an angle and radius from the center. These values are then animated over time: the angle is increased to create a spiral, and the radius is decreased to pull the image into the center.
+-   The number of spirals is a configurable parameter within the class, making the effect easy to adjust.
+
+### 2. Integration & Testing
+
+-   The new animation was exported from `src/index.ts` and registered in the `demo/main.ts` file, making it immediately available in the demo application.
+-   A new test suite was created in `tests/animations/VortexAnimation.test.ts`.
+-   The tests verify the core mechanics: that the mesh is created and destroyed correctly, and that the vertex data is modified by the `update` method.
+-   A specific test was added to verify that at the end of the 3-second animation, all vertices have been successfully pulled to the center of the mesh, confirming the animation's end state.
+
+### 4. Verification
+
+-   All programmatic checks specified in `AGENTS.md` passed without issue:
+    -   `npm run test`: All 57 tests passed.
+    -   `npm run build`: The library and demo both built successfully.
+
+## Conclusion
+
+The task is complete. The `VortexAnimation` provides a powerful and visually complex effect, demonstrating the flexibility of using meshes for advanced animations. The implementation is robust, tested, and fully integrated into the library.

--- a/src/animations/VortexAnimation.ts
+++ b/src/animations/VortexAnimation.ts
@@ -1,0 +1,98 @@
+import { BaseAnimate } from '../core/BaseAnimate';
+import * as PIXI from 'pixi.js';
+
+/**
+ * @class VortexAnimation
+ * @extends BaseAnimate
+ * @description Creates a "black hole" vortex effect on a sprite's texture using a MeshPlane.
+ * The image is rotated and pulled into the center over the duration.
+ */
+export class VortexAnimation extends BaseAnimate {
+    public static readonly animationName: string = 'Vortex';
+
+    public static getRequiredSpriteCount(): number {
+        return 1;
+    }
+
+    private mesh: PIXI.MeshPlane | null = null;
+    private readonly originalVertices: Float32Array;
+    private readonly sourceSprite: PIXI.Sprite;
+
+    // Animation parameters
+    private readonly DURATION: number = 3.0; // Total duration in seconds
+    private readonly segments = { width: 20, height: 20 };
+    private readonly spirals: number = 3; // How many times the image will spiral
+    private elapsedTime: number = 0;
+
+    constructor(object: any, sprites: PIXI.Sprite[]) {
+        super(object, sprites);
+        this.sourceSprite = sprites[0];
+
+        this.mesh = new PIXI.MeshPlane({
+            texture: this.sourceSprite.texture,
+            verticesX: this.segments.width,
+            verticesY: this.segments.height,
+        });
+
+        this.mesh.width = this.sourceSprite.width;
+        this.mesh.height = this.sourceSprite.height;
+
+        this.originalVertices = new Float32Array(this.mesh.geometry.getBuffer('aPosition').data);
+
+        this.object.addChild(this.mesh);
+        this.sourceSprite.visible = false;
+    }
+
+    public update(deltaTime: number): void {
+        if (!this.isPlaying || !this.mesh) {
+            return;
+        }
+
+        this.elapsedTime += deltaTime;
+        const progress = Math.min(this.elapsedTime / this.DURATION, 1.0);
+
+        const positionBuffer = this.mesh.geometry.getBuffer('aPosition');
+        const vertices = positionBuffer.data;
+        const totalVertices = (this.segments.width + 1) * (this.segments.height + 1);
+
+        const centerX = this.mesh.width / 2;
+        const centerY = this.mesh.height / 2;
+
+        for (let i = 0; i < totalVertices; i++) {
+            const ox = this.originalVertices[i * 2];
+            const oy = this.originalVertices[i * 2 + 1];
+
+            const dx = ox - centerX;
+            const dy = oy - centerY;
+
+            const originalRadius = Math.sqrt(dx * dx + dy * dy);
+            const originalAngle = Math.atan2(dy, dx);
+
+            const newRadius = originalRadius * (1 - progress);
+            const newAngle = originalAngle + progress * this.spirals * Math.PI * 2;
+
+            vertices[i * 2] = centerX + newRadius * Math.cos(newAngle);
+            vertices[i * 2 + 1] = centerY + newRadius * Math.sin(newAngle);
+        }
+
+        positionBuffer.update();
+
+        if (this.elapsedTime >= this.DURATION) {
+            this.elapsedTime = this.elapsedTime % this.DURATION;
+            if (this.onComplete) this.onComplete();
+        }
+    }
+
+    public stop(): void {
+        super.stop();
+        this.elapsedTime = 0;
+
+        if (this.mesh) {
+            this.object.removeChild(this.mesh);
+            this.mesh.destroy();
+            this.mesh = null;
+        }
+
+        this.sourceSprite.visible = true;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export { ScaleAnimation } from './animations/ScaleAnimation';
 export { FadeAnimation } from './animations/FadeAnimation';
 export { ComplexPopAnimation } from './animations/ComplexPopAnimation';
 export { FlagWaveAnimation } from './animations/FlagWaveAnimation';
+export { VortexAnimation } from './animations/VortexAnimation';

--- a/tests/animations/VortexAnimation.test.ts
+++ b/tests/animations/VortexAnimation.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { VortexAnimation } from '../../src/animations/VortexAnimation';
+import { BaseObject } from '../../src/core/BaseObject';
+import * as PIXI from 'pixi.js';
+
+// Mock PIXI classes
+vi.mock('pixi.js', async () => {
+    const actual = await vi.importActual('pixi.js');
+
+    const buffer = {
+        data: new Float32Array(Array.from({ length: 441 * 2 }, (_, i) => (i % 2 === 0 ? (i / 2) % 21 * 10 : Math.floor(i / 42) * 10))),
+        update: vi.fn(),
+    };
+
+    const MeshPlane = vi.fn(() => ({
+        geometry: {
+            getBuffer: vi.fn((id) => {
+                if (id === 'aPosition') return buffer;
+                return null;
+            }),
+        },
+        width: 200,
+        height: 200,
+        destroy: vi.fn(),
+    }));
+
+    const Sprite = vi.fn(() => ({
+        texture: {},
+        visible: true,
+        width: 200,
+        height: 200,
+    }));
+
+    return {
+        ...actual,
+        MeshPlane,
+        Sprite,
+    };
+});
+
+describe('VortexAnimation', () => {
+    let object: BaseObject;
+    let sprite: PIXI.Sprite;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        object = new BaseObject();
+        vi.spyOn(object, 'addChild').mockImplementation((child) => child);
+        vi.spyOn(object, 'removeChild').mockImplementation((child) => child);
+        sprite = new PIXI.Sprite();
+    });
+
+    it('should create a MeshPlane and hide the source sprite on construction', () => {
+        const animation = new VortexAnimation(object, [sprite]);
+
+        expect(PIXI.MeshPlane).toHaveBeenCalledOnce();
+        expect(object.addChild).toHaveBeenCalledOnce();
+        expect(sprite.visible).toBe(false);
+    });
+
+    it('should update mesh vertices when update is called', () => {
+        const animation = new VortexAnimation(object, [sprite]);
+        const mesh = (object.addChild as any).mock.calls[0][0];
+        const buffer = mesh.geometry.getBuffer('aPosition');
+        const originalVertices = new Float32Array(buffer.data);
+
+        animation.play();
+        animation.update(0.1);
+
+        expect(buffer.data).not.toEqual(originalVertices);
+        expect(buffer.update).toHaveBeenCalledOnce();
+    });
+
+    it('should pull vertices to the center at the end of the animation', () => {
+        const animation = new VortexAnimation(object, [sprite]);
+        const mesh = (object.addChild as any).mock.calls[0][0];
+        const buffer = mesh.geometry.getBuffer('aPosition');
+
+        animation.play();
+        animation.update(3.0); // End of animation
+
+        // All vertices should be at the center (100, 100)
+        for (let i = 0; i < buffer.data.length; i += 2) {
+            expect(buffer.data[i]).toBeCloseTo(100);
+            expect(buffer.data[i + 1]).toBeCloseTo(100);
+        }
+    });
+
+    it('should destroy the mesh and restore the sprite on stop', () => {
+        const animation = new VortexAnimation(object, [sprite]);
+        const mesh = (object.addChild as any).mock.calls[0][0];
+
+        expect(sprite.visible).toBe(false);
+
+        animation.stop();
+
+        expect(object.removeChild).toHaveBeenCalledWith(mesh);
+        expect(mesh.destroy).toHaveBeenCalledOnce();
+        expect(sprite.visible).toBe(true);
+    });
+});


### PR DESCRIPTION
This commit introduces `VortexAnimation`, a new mesh-based animation that creates a vortex effect.

The animation pulls the vertices of a `PIXI.MeshPlane` towards the center while rotating them, simulating the visual of a texture being sucked into a black hole. The implementation uses polar coordinates to achieve a smooth spiral motion.

The new animation is tested for its mechanical functionality and has been integrated into the demo application.